### PR TITLE
Fixed Netlify CLI installation command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install Netlify CLI
         if: github.ref == 'refs/heads/master'
-        run: sudo npm install netlify-cli -g
+        run: sudo npm install --unsafe-perm=true netlify-cli -g
 
       - name: Deploy
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
The `Install Netlify CLI` step in GitHub Actions fails due to a change in the CLI, see netlify/cli#1870.
Adding the `--unsafe-perm=true` fixes this.