### PR TITLE
Fix typo in readme manual deployment command

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ And how to setup Github Actions with deploy into Netlify.
 
 ### Manual Deployment
 
-1. Run `yarn build:realease`.
+1. Run `yarn build:release`.
 1. Check if build works by running `yarn serve:dist` and view in a browser.
 1. Deploy the contents of the `dist` directory to a web server.
 


### PR DESCRIPTION
Was trying to setup a project using this template, noticed that the manual deployment command had a typo (realease instead of release) causing it to fail.